### PR TITLE
Add event demux code to async-tracker

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -56,26 +56,6 @@ The AsyncTracker object is exposed as a global variable named `asyncTracker`.
 `name`: Optional. Listener name for the new listener, or an existing listener which should be replaced.
 `listenerObj`: An object which contains several optional fields. This listener will be associated with all async operations that will be scheduled and all objects that will be created.
 
-* `deferredCreated(fName, cbId, fData)`: A function which is called when an async callback is scheduled.
-** `fName`: A name of the function that scheduled the callback.
-** `cbId`: Unique ID of this callback
-** `fData`: If the listener specified interest in function arguments, `fData` will contain a map of the significant arguments
-* `invokeDeferred(fName, cbId, next)`: A function can intercept the invocation of an async callback. This function behaves similar to Express middleware and you must call `next()` to continue invocation of the callback. Other libraries can use this call to run their own code before and after function execution. They may also choose to wrap the function invocation in a try/catch/finally block to catch and handle exceptions.
-** `fName`: A name of the function that scheduled the callback.
-** `cbId`: Unique ID of this callback
-** `next`: The callback function to execute
-* `deferredReleased(fName, cbId)`: A function
-** `fName`: A name of the function that scheduled the callback.
-** `cbId`: Unique ID of this callback
-* `trackObject(obj)`: A function which is called when an Observable object is created
-** `obj`: The observable object
-* `releaseObject(obj)`: A function which is called when an Observable object is closed, destroyed or, explicitly released.
-** `obj`: The observable object
-
-Returns the name of the listener that was added
-
-WARNING: Be very careful about the implementation of these functions. They will be invoked often and can result in significant performance issues. Calling function that are async from these callbacks can result in an infinite loop
-
 [[asynctrackerremovelistenerlistenername]]
 ==== asyncTracker.removeListener(listenerName)
 
@@ -109,6 +89,85 @@ Called when a function is complete and will no longer be called in the future.
 
 * `fName`: A name of the function that scheduled the callback.
 * `cbId`: Unique ID of this callback
+
+=== Listener Object interface
+
+WARNING: Be very careful about the implementation of these functions. They will be invoked often and can result in significant performance issues. Calling function that are async from these callbacks can result in an infinite loop
+
+=== Listener.deferredCreated
+
+Map of callback functions for events that this Listener is interested in.
+
+Callback:
+
+* `deferredCreated(fName, cbId, fData)`: A function which is called when an async callback is scheduled.
+** `fName`: A name of the function that scheduled the callback.
+** `cbId`: Unique ID of this callback
+** `fData`: If the listener specified interest in function arguments, `fData` will contain a map of the significant arguments
+
+Example:
+
+```
+Listener.deferredCreated[fs.open] = function callback(fName, cbId, fData){...};
+Listener.deferredCreated['default'] = function defaultCallback(fName, cbId, fData){...};
+```
+
+=== Listener.invokeDeferred
+
+Map of callback functions for events that this Listener is interested in.
+
+Callback:
+
+* `invokeDeferred(fName, cbId, next)`: A function can intercept the invocation of an async callback. This function behaves similar to Express middleware and you must call `next()` to continue invocation of the callback. Other libraries can use this call to run their own code before and after function execution. They may also choose to wrap the function invocation in a try/catch/finally block to catch and handle exceptions.
+** `fName`: A name of the function that scheduled the callback.
+** `cbId`: Unique ID of this callback
+** `next`: The callback function to execute
+
+Example:
+
+```
+Listener.invokeDeferred[fs.open] = function callback(fName, cbId, next){...};
+Listener.invokeDeferred['default'] = function defaultCallback(fName, cbId, next){...};
+```
+
+=== Listener.deferredReleased
+
+Map of callback functions for events that this Listener is interested in.
+
+Callback:
+
+* `deferredReleased(fName, cbId)`: A function
+** `fName`: A name of the function that scheduled the callback.
+** `cbId`: Unique ID of this callback
+
+Example:
+
+```
+Listener.deferredReleased[fs.open] = function callback(fName, cbId){...};
+Listener.deferredReleased['default'] = function defaultCallback(fName, cbId){...};
+```
+
+=== Listener.trackObject(obj)
+
+* `trackObject(obj)`: A function which is called when an Observable object is created
+** `obj`: The observable object
+
+Example:
+
+```
+Listener.trackObject = function callback(obj){...};
+```
+
+=== Listener.releaseObject(obj)
+
+* `releaseObject(obj)`: A function which is called when an Observable object is closed, destroyed or, explicitly released.
+** `obj`: The observable object
+
+Example:
+
+```
+Listener.releaseObject = function callback(obj){...};
+```
 
 === AsyncTracker Observable interface
 

--- a/lib/async-tracker.js
+++ b/lib/async-tracker.js
@@ -53,9 +53,12 @@ AsyncTracker.prototype.deferredCreated = function(fName, cbId, fData) {
   var keys = Object.keys(this.listeners);
   var len = keys.length;
   for (var i = 0; i < len; i += 1) {
-    if (this.listeners[keys[i]].deferredCreated) {
-      this.listeners[keys[i]].deferredCreated(fName, cbId, fData);
+    var fn = this.listeners[keys[i]].deferredCreated[fName];
+    if (!fn && this.listeners[keys[i]].deferredCreated['default']) {
+      fn = this.listeners[keys[i]].deferredCreated['default'];
     }
+
+    if (fn) fn(fName, cbId);
   }
 };
 
@@ -71,8 +74,10 @@ function _runDeferred() {
     _next();
   } else {
     var curListener = _runList[_runListKeys[_runItrPos]];
-    if (curListener.invokeDeferred) {
-      curListener.invokeDeferred(_fName, _cbId, _runDeferred);
+    if (curListener.invokeDeferred[_fName]) {
+      curListener.invokeDeferred[_fName](_fName, _cbId, _runDeferred);
+    } else if(curListener.invokeDeferred['default']) {
+      curListener.invokeDeferred['default'](_fName, _cbId, _runDeferred);
     } else {
       _runDeferred();
     }
@@ -94,9 +99,12 @@ AsyncTracker.prototype.deferredReleased = function(fName, cbId) {
   var keys = Object.keys(this.listeners);
   var len = keys.length;
   for (var i = 0; i < len; i += 1) {
-    if (this.listeners[keys[i]].deferredReleased) {
-      this.listeners[keys[i]].deferredReleased(fName, cbId);
+    var fn = this.listeners[keys[i]].deferredReleased[fName];
+    if (!fn && this.listeners[keys[i]].deferredReleased['default']) {
+      fn = this.listeners[keys[i]].deferredReleased['default'];
     }
+
+    if (fn) fn(fName, cbId);
   }
 };
 

--- a/test/test-add-remove-listener.js
+++ b/test/test-add-remove-listener.js
@@ -3,24 +3,28 @@ require('../index.js');
 
 var cnt=0;
 var Listener = function(_expectEvents) {
-  this.expectEvents = _expectEvents;
-}
+  var evtName = asyncTracker.events.process.nextTick;
+  
+  this.deferredCreated = {};
+  this.invokeDeferred = {};
+  this.deferredReleased = {};
 
-Listener.prototype.deferredCreated = function(fName, fId) {
-  assert(this.expectEvents);
-  cnt++;
-}
+  this.deferredCreated[evtName] = function(fName, fId) {
+    assert(_expectEvents);
+    cnt++;
+  };
 
-Listener.prototype.invokeDeferred = function(fName, fId, next) {
-  assert(this.expectEvents);
-  cnt++;
-  next();
-}
+  this.invokeDeferred[evtName] = function(fName, fId, next) {
+    assert(_expectEvents);
+    cnt++;
+    next();
+  };
 
-Listener.prototype.deferredReleased = function(fName, fId) {
-  assert(this.expectEvents);
-  cnt++;
-}
+  this.deferredReleased[evtName] = function(fName, fId) {
+    assert(_expectEvents);
+    cnt++;
+  };
+};
 
 function cb() {
 }

--- a/test/test-clearImmediate.js
+++ b/test/test-clearImmediate.js
@@ -4,26 +4,30 @@ require('../');
 
 var cnt = 0;
 var Listener = function() {
-}
+  this.deferredCreated = {};
+  this.invokeDeferred = {};
+  this.deferredReleased = {};
+  var evtName = asyncTracker.events.global.setImmediate;
 
-Listener.prototype.deferredCreated = function(fName, fId) {
-  assert.equal(fName, asyncTracker.events.global.setImmediate);
-  assert.equal(cnt, 0);
-  cnt++;
-}
+  this.deferredCreated[evtName] = function(fName, fId) {
+    assert.equal(fName, evtName);
+    assert.equal(cnt, 0);
+    cnt++;
+  };
 
-Listener.prototype.invokeDeferred = function(fName, fId, next) {
-  assert.equal(fName, asyncTracker.events.global.setImmediate);
-  assert(false, 'should not be called');
-  cnt++;
-  next();
-}
+  this.invokeDeferred[evtName] = function(fName, fId, next) {
+    assert.equal(fName, evtName);
+    assert(false, 'should not be called');
+    cnt++;
+    next();
+  };
 
-Listener.prototype.deferredReleased = function(fName, fId) {
-  assert.equal(fName, asyncTracker.events.global.setImmediate);
-  assert.equal(cnt, 1);
-  cnt++;
-}
+  this.deferredReleased[evtName] = function(fName, fId) {
+    assert.equal(fName, evtName);
+    assert.equal(cnt, 1);
+    cnt++;
+  };
+};
 
 function cb() {
   assert(false, 'should not be called');  

--- a/test/test-fs-open-close.js
+++ b/test/test-fs-open-close.js
@@ -5,45 +5,54 @@ var util = require('util');
 var cnt = 0;
 
 var Listener = function() {
-}
+  var evtName = asyncTracker.events.fs.open;
 
-Listener.prototype.deferredCreated = function(fName, fId, args) {
-  if (fName === asyncTracker.events.fs.open) {
+  this.deferredCreated = {};
+  this.invokeDeferred = {};
+  this.deferredReleased = {};
+
+  this.deferredCreated[evtName] = function(fName, fId, args) {
     assert.equal(cnt, 0);
-  } else {
+    cnt += 1;
+  };
+
+  this.deferredCreated['default'] = function(fName, fId, args) {
     assert.equal(cnt, 4);
-  }
-  cnt += 1;
-}
+    cnt += 1;
+  };
 
-Listener.prototype.invokeDeferred = function(fName, fId, next) {
-  if (fName === asyncTracker.events.fs.open) {
+  this.invokeDeferred[evtName] = function(fName, fId, next) {
     assert.equal(cnt, 2);
-  } else {
+    cnt += 1;
+    next();
+  };
+
+  this.invokeDeferred['default'] = function(fName, fId, next) {
     assert.equal(cnt, 6);
-  }
-  cnt += 1;
-  next();
-}
+    cnt += 1;
+    next();
+  };
 
-Listener.prototype.deferredReleased = function(fName, fId) {
-  if (fName === asyncTracker.events.fs.open) {
+  this.deferredReleased[evtName] = function(fName, fId) {
     assert.equal(cnt, 5);
-  } else {
+    cnt += 1;
+  };
+
+  this.deferredReleased['default'] = function(fName, fId) {
     assert.equal(cnt, 7);
-  }
-  cnt += 1;
-}
+    cnt += 1;
+  };
 
-Listener.prototype.objectCreated = function(obj) {
-  assert.equal(cnt, 1);
-  cnt += 1;
-}
+  this.objectCreated = function(obj) {
+    assert.equal(cnt, 1);
+    cnt += 1;
+  };
 
-Listener.prototype.objectReleased = function(obj) {
-  assert.equal(cnt, 3);
-  cnt += 1;
-}
+  this.objectReleased = function(obj) {
+    assert.equal(cnt, 3);
+    cnt += 1;
+  };
+};
 
 var listener = new Listener();
 asyncTracker.addListener(listener, 'listener');

--- a/test/test-nextTick.js
+++ b/test/test-nextTick.js
@@ -4,26 +4,31 @@ require('../');
 
 var cnt = 0;
 var Listener = function() {
-}
+  var evtName = asyncTracker.events.process.nextTick;
 
-Listener.prototype.deferredCreated = function(fName, fId) {
-  assert.equal(fName, asyncTracker.events.process.nextTick);
-  assert.equal(cnt, 0);
-  cnt++;
-}
+  this.deferredCreated = {};
+  this.invokeDeferred = {};
+  this.deferredReleased = {};
 
-Listener.prototype.invokeDeferred = function(fName, fId, next) {
-  assert.equal(fName, asyncTracker.events.process.nextTick);
-  assert.equal(cnt, 1);
-  cnt++;
-  next();
-}
+  this.deferredCreated[evtName] = function(fName, fId) {
+    assert.equal(fName, evtName);
+    assert.equal(cnt, 0);
+    cnt++;
+  };
 
-Listener.prototype.deferredReleased = function(fName, fId) {
-  assert.equal(fName, asyncTracker.events.process.nextTick);
-  assert.equal(cnt, 3);
-  cnt++;
-}
+  this.invokeDeferred[evtName] = function(fName, fId, next) {
+    assert.equal(fName, evtName);
+    assert.equal(cnt, 1);
+    cnt++;
+    next();
+  };
+
+  this.deferredReleased[evtName] = function(fName, fId) {
+    assert.equal(fName, asyncTracker.events.process.nextTick);
+    assert.equal(cnt, 3);
+    cnt++;
+  };
+};
 
 function cb() {
   assert.equal(cnt, 2);

--- a/test/test-setImmediate.js
+++ b/test/test-setImmediate.js
@@ -4,26 +4,31 @@ require('../');
 
 var cnt = 0;
 var Listener = function() {
-}
+  var evtName = asyncTracker.events.global.setImmediate;
 
-Listener.prototype.deferredCreated = function(fName, fId) {
-  assert.equal(fName, asyncTracker.events.global.setImmediate);
-  assert.equal(cnt, 0);
-  cnt++;
-}
+  this.deferredCreated = {};
+  this.invokeDeferred = {};
+  this.deferredReleased = {};
 
-Listener.prototype.invokeDeferred = function(fName, fId, next) {
-  assert.equal(fName, asyncTracker.events.global.setImmediate);
-  assert.equal(cnt, 1);
-  cnt++;
-  next();
-}
+  this.deferredCreated[evtName] = function(fName, fId) {
+    assert.equal(fName, evtName);
+    assert.equal(cnt, 0);
+    cnt++;
+  };
 
-Listener.prototype.deferredReleased = function(fName, fId) {
-  assert.equal(fName, asyncTracker.events.global.setImmediate);
-  assert.equal(cnt, 3);
-  cnt++;
-}
+  this.invokeDeferred[evtName] = function(fName, fId, next) {
+    assert.equal(fName, evtName);
+    assert.equal(cnt, 1);
+    cnt++;
+    next();
+  };
+
+  this.deferredReleased[evtName] = function(fName, fId) {
+    assert.equal(fName, evtName);
+    assert.equal(cnt, 3);
+    cnt++;
+  };
+};
 
 function cb() {
   assert.equal(cnt, 2);


### PR DESCRIPTION
Moves responsibility to match/filter async method name to async-tracker but allows user to register a 'default' handler which is notified about all async methods.

Fixes 2 issue in https://github.com/strongloop/async-tracker/issues/1
